### PR TITLE
Fixes json var parsing on chaining methods

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -6,6 +6,7 @@ pub enum Expr {
     Unary(UnaryOp, Box<Expr>),
     Binary(Box<Expr>, BinaryOp, Box<Expr>),
     Variable(String),
+    PropertyAccess { target: Box<Expr>, property: String },
     FunctionCall { name: String, args: Vec<Expr> },
     Spread(Box<Expr>),
     Array(Vec<Expr>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub fn evaluate_with_json(input: &str, json_vars: &str) -> Result<Value, Error> 
 }
 
 /// Convert serde_json::Value to skillet::Value with type inference
-fn json_to_value(json: serde_json::Value) -> Result<Value, Error> {
+pub fn json_to_value(json: serde_json::Value) -> Result<Value, Error> {
     match json {
         serde_json::Value::Null => Ok(Value::Null),
         serde_json::Value::Bool(b) => Ok(Value::Boolean(b)),


### PR DESCRIPTION
Fixes the usage of expressions like:

```
sk "=IF(:config.enabled, :config.price * :config.quantity, 0)" --json '{                                                                                                                                              [2:43:26]
  "config": {
    "enabled": true,
    "price": 25.50,
    "quantity": 4
  }
}'
```

or 

```
sk "=:user.name.upper()" --json '{"user": {"name": "alice"}}' --output-json
```