### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/zenbakiak/skillet/security/code-scanning/2](https://github.com/zenbakiak/skillet/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/rust.yml` at the workflow root level (right after `on:` section, before `env:` is a clean location).  
For this workflow, the least-privilege baseline is:

- `contents: read`

This preserves current functionality (`actions/checkout` + local build/test) while preventing unintended broader token access if repo/org defaults are permissive or change later. No imports, methods, or dependencies are needed—just YAML configuration in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
